### PR TITLE
Fix: Correct syntax errors in generated code and add tests

### DIFF
--- a/ReflectionGenerator.Tests/EnumGenerationTests.cs
+++ b/ReflectionGenerator.Tests/EnumGenerationTests.cs
@@ -1,0 +1,156 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ReflectionGenerator;
+using Mono.Cecil;
+using System;
+using System.IO;
+using System.Linq;
+
+namespace ReflectionGenerator.Tests
+{
+    [TestClass]
+    public class EnumGenerationTests
+    {
+        private static ModuleDefinition _testModule;
+        private static string _tempOutputDir;
+
+        [ClassInitialize]
+        public static void ClassInitialize(TestContext context)
+        {
+            var assemblyDef = AssemblyDefinition.CreateAssembly(
+                new AssemblyNameDefinition("TestAssemblyForEnumsGen", new Version(1, 0)),
+                "TestModuleForEnumsGen",
+                ModuleKind.Dll);
+            _testModule = assemblyDef.MainModule;
+            _tempOutputDir = Path.Combine(Path.GetTempPath(), "ReflectionGenTests_Enums");
+            if (Directory.Exists(_tempOutputDir))
+            {
+                Directory.Delete(_tempOutputDir, true);
+            }
+            Directory.CreateDirectory(_tempOutputDir);
+        }
+
+        [ClassCleanup]
+        public static void ClassCleanup()
+        {
+            if (Directory.Exists(_tempOutputDir))
+            {
+                Directory.Delete(_tempOutputDir, true);
+            }
+        }
+        
+        private TypeReference ImportType(Type type)
+        {
+            return _testModule.ImportReference(type);
+        }
+
+        private string GenerateAndReadFile(TypeDefinition typeDef)
+        {
+            if (!_testModule.Types.Contains(typeDef))
+            {
+                _testModule.Types.Add(typeDef);
+            }
+            
+            string sanitizedNamespace = string.IsNullOrEmpty(typeDef.Namespace) ? "" : Program.SanitizeFileNameComponent(typeDef.Namespace);
+            // GetTypeName for enum returns its simple name, which should be sanitized.
+            string sanitizedTypeName = Program.SanitizeFileNameComponent(Program.GetTypeName(typeDef)); 
+
+            string expectedFileName = Path.Combine(_tempOutputDir, 
+                string.IsNullOrEmpty(sanitizedNamespace) ? $"{sanitizedTypeName}.cs" : $"{sanitizedNamespace}.{sanitizedTypeName}.cs");
+
+            Program.GenerateTypeScaffolding(typeDef, _tempOutputDir);
+            
+            if (!File.Exists(expectedFileName))
+            {
+                Assert.Fail($"Expected file '{expectedFileName}' was not generated. Namespace: '{typeDef.Namespace}', Name: '{typeDef.Name}'");
+            }
+            return File.ReadAllText(expectedFileName);
+        }
+
+        [TestMethod]
+        public void GenerateEnum_WithDefaultUnderlyingType_GeneratesCorrectly()
+        {
+            var enumDef = new TypeDefinition("Test.Enums", "MySimpleEnum", TypeAttributes.Public | TypeAttributes.Sealed, ImportType(typeof(Enum)));
+            enumDef.IsEnum = true;
+            // Mono.Cecil requires a field named "value__" for enums, representing the instance field for the enum's value.
+            var valueField = new FieldDefinition("value__", FieldAttributes.Public | FieldAttributes.SpecialName | FieldAttributes.RTSpecialName, _testModule.TypeSystem.Int32);
+            enumDef.Fields.Add(valueField);
+
+            var member1 = new FieldDefinition("OptionOne", FieldAttributes.Public | FieldAttributes.Static | FieldAttributes.Literal | FieldAttributes.HasDefault, enumDef);
+            member1.Constant = 10;
+            enumDef.Fields.Add(member1);
+
+            var member2 = new FieldDefinition("OptionTwo", FieldAttributes.Public | FieldAttributes.Static | FieldAttributes.Literal | FieldAttributes.HasDefault, enumDef);
+            member2.Constant = 20;
+            enumDef.Fields.Add(member2);
+            
+            string output = GenerateAndReadFile(enumDef);
+
+            StringAssert.Contains(output, "namespace Test.Enums");
+            StringAssert.Contains(output, "public enum MySimpleEnum : int"); // Default is int
+            StringAssert.Contains(output, "OptionOne = 10,");
+            StringAssert.Contains(output, "OptionTwo = 20");
+            _testModule.Types.Remove(enumDef);
+        }
+
+        [TestMethod]
+        public void GenerateEnum_WithLongUnderlyingTypeAndFlags_GeneratesCorrectly()
+        {
+            var enumDef = new TypeDefinition("Test.Flags", "MyLongFlags", TypeAttributes.Public | TypeAttributes.Sealed, ImportType(typeof(Enum)));
+            enumDef.IsEnum = true;
+            var valueField = new FieldDefinition("value__", FieldAttributes.Public | FieldAttributes.SpecialName | FieldAttributes.RTSpecialName, _testModule.TypeSystem.Int64); // Long
+            enumDef.Fields.Add(valueField);
+
+            // Add [Flags] attribute
+            var flagsCtor = _testModule.ImportReference(typeof(FlagsAttribute).GetConstructor(Type.EmptyTypes));
+            enumDef.CustomAttributes.Add(new CustomAttribute(flagsCtor));
+
+            var member1 = new FieldDefinition("FlagA", FieldAttributes.Public | FieldAttributes.Static | FieldAttributes.Literal | FieldAttributes.HasDefault, enumDef);
+            member1.Constant = 1L; // Long value
+            enumDef.Fields.Add(member1);
+
+            var member2 = new FieldDefinition("FlagB", FieldAttributes.Public | FieldAttributes.Static | FieldAttributes.Literal | FieldAttributes.HasDefault, enumDef);
+            member2.Constant = 2L; // Long value
+            enumDef.Fields.Add(member2);
+            
+            var member3 = new FieldDefinition("FlagC", FieldAttributes.Public | FieldAttributes.Static | FieldAttributes.Literal | FieldAttributes.HasDefault, enumDef);
+            member3.Constant = 0x100000000L; // > Int32.MaxValue
+            enumDef.Fields.Add(member3);
+
+
+            string output = GenerateAndReadFile(enumDef);
+
+            StringAssert.Contains(output, "namespace Test.Flags");
+            StringAssert.Contains(output, "[Flags]");
+            StringAssert.Contains(output, "public enum MyLongFlags : long");
+            StringAssert.Contains(output, "FlagA = 1L,");
+            StringAssert.Contains(output, "FlagB = 2L,");
+            StringAssert.Contains(output, $"FlagC = {0x100000000L}L"); // Check the large long value
+            _testModule.Types.Remove(enumDef);
+        }
+        
+        [TestMethod]
+        public void GenerateEnum_WithByteUnderlyingType_GeneratesCorrectly()
+        {
+            var enumDef = new TypeDefinition("Test.Bytes", "MyByteEnum", TypeAttributes.Public | TypeAttributes.Sealed, ImportType(typeof(Enum)));
+            enumDef.IsEnum = true;
+            var valueField = new FieldDefinition("value__", FieldAttributes.Public | FieldAttributes.SpecialName | FieldAttributes.RTSpecialName, _testModule.TypeSystem.Byte); // Byte
+            enumDef.Fields.Add(valueField);
+
+            var member1 = new FieldDefinition("LowByte", FieldAttributes.Public | FieldAttributes.Static | FieldAttributes.Literal | FieldAttributes.HasDefault, enumDef);
+            member1.Constant = (byte)5;
+            enumDef.Fields.Add(member1);
+
+            var member2 = new FieldDefinition("HighByte", FieldAttributes.Public | FieldAttributes.Static | FieldAttributes.Literal | FieldAttributes.HasDefault, enumDef);
+            member2.Constant = (byte)250;
+            enumDef.Fields.Add(member2);
+            
+            string output = GenerateAndReadFile(enumDef);
+
+            StringAssert.Contains(output, "namespace Test.Bytes");
+            StringAssert.Contains(output, "public enum MyByteEnum : byte");
+            StringAssert.Contains(output, "LowByte = 5,");
+            StringAssert.Contains(output, "HighByte = 250");
+            _testModule.Types.Remove(enumDef);
+        }
+    }
+}

--- a/ReflectionGenerator.Tests/EscapeStringForAttributeTests.cs
+++ b/ReflectionGenerator.Tests/EscapeStringForAttributeTests.cs
@@ -1,0 +1,99 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ReflectionGenerator; // Assuming Program class is in this namespace
+
+namespace ReflectionGenerator.Tests
+{
+    [TestClass]
+    public class EscapeStringForAttributeTests
+    {
+        [TestMethod]
+        public void EscapeStringForAttribute_WithMessageWithQuotes_EscapesQuotes()
+        {
+            string input = "This is a \"test\" message.";
+            string expected = "This is a \\\"test\\\" message.";
+            string? actual = Program.EscapeStringForAttribute(input);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void EscapeStringForAttribute_WithMessageWithBackslashes_EscapesBackslashes()
+        {
+            string input = "Path is C:\\Temp\\File";
+            string expected = "Path is C:\\\\Temp\\\\File";
+            string? actual = Program.EscapeStringForAttribute(input);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void EscapeStringForAttribute_WithMessageWithNewlines_EscapesNewlines()
+        {
+            string input = "Line1\nLine2";
+            string expected = "Line1\\nLine2";
+            string? actual = Program.EscapeStringForAttribute(input);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void EscapeStringForAttribute_WithMessageWithCarriageReturns_EscapesCarriageReturns()
+        {
+            string input = "Line1\rLine2";
+            string expected = "Line1\\rLine2";
+            string? actual = Program.EscapeStringForAttribute(input);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void EscapeStringForAttribute_WithMessageWithTabs_EscapesTabs()
+        {
+            string input = "Column1\tColumn2";
+            string expected = "Column1\\tColumn2";
+            string? actual = Program.EscapeStringForAttribute(input);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void EscapeStringForAttribute_WithMessageWithMixedSpecialChars_EscapesAll()
+        {
+            string input = "A \"mix\"\n of \\special\\ chars.";
+            string expected = "A \\\"mix\\\"\\n of \\\\special\\\\ chars.";
+            string? actual = Program.EscapeStringForAttribute(input);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void EscapeStringForAttribute_EmptyString_ReturnsEmptyString()
+        {
+            string input = "";
+            string expected = "";
+            string? actual = Program.EscapeStringForAttribute(input);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void EscapeStringForAttribute_NullString_ReturnsNull()
+        {
+            string? input = null;
+            string? expected = null;
+            string? actual = Program.EscapeStringForAttribute(input);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void EscapeStringForAttribute_NoSpecialChars_ReturnsSameString()
+        {
+            string input = "This is a simple message.";
+            string expected = "This is a simple message.";
+            string? actual = Program.EscapeStringForAttribute(input);
+            Assert.AreEqual(expected, actual);
+        }
+        
+        [TestMethod]
+        public void EscapeStringForAttribute_WithControlChars_EscapesToUnicode()
+        {
+            string input = "Bell sound \a and backspace \b"; // \a (alert) and \b (backspace) are control chars
+            string expected = "Bell sound \\u0007 and backspace \\u0008";
+            string? actual = Program.EscapeStringForAttribute(input);
+            Assert.AreEqual(expected, actual);
+        }
+    }
+}

--- a/ReflectionGenerator.Tests/FormatEnumMemberValueTests.cs
+++ b/ReflectionGenerator.Tests/FormatEnumMemberValueTests.cs
@@ -1,0 +1,105 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ReflectionGenerator; // Assuming Program class is in this namespace
+using Mono.Cecil;
+
+namespace ReflectionGenerator.Tests
+{
+    [TestClass]
+    public class FormatEnumMemberValueTests
+    {
+        private static ModuleDefinition _testModule;
+
+        [ClassInitialize]
+        public static void ClassInitialize(TestContext context)
+        {
+            // Create a dummy module to import type references
+            var assemblyDef = AssemblyDefinition.CreateAssembly(
+                new AssemblyNameDefinition("TestAssemblyForEnums", new Version(1, 0)),
+                "TestModuleForEnums",
+                ModuleKind.Dll);
+            _testModule = assemblyDef.MainModule;
+        }
+
+        [TestMethod]
+        public void FormatEnumMemberValue_Int_ReturnsStringAsIs()
+        {
+            object value = 123;
+            TypeReference underlyingType = _testModule.TypeSystem.Int32;
+            string expected = "123";
+            string actual = Program.FormatEnumMemberValue(value, underlyingType);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void FormatEnumMemberValue_Long_AppendsL()
+        {
+            object value = 1234567890123L;
+            TypeReference underlyingType = _testModule.TypeSystem.Int64;
+            string expected = "1234567890123L";
+            string actual = Program.FormatEnumMemberValue(value, underlyingType);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void FormatEnumMemberValue_ULong_AppendsUL()
+        {
+            object value = 1234567890123UL;
+            TypeReference underlyingType = _testModule.TypeSystem.UInt64;
+            string expected = "1234567890123UL";
+            string actual = Program.FormatEnumMemberValue(value, underlyingType);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void FormatEnumMemberValue_UInt_ReturnsStringAsIs()
+        {
+            // The method currently returns ToString() for uint, which is fine.
+            // If explicit "U" suffix were desired, this test would change.
+            object value = (uint)456;
+            TypeReference underlyingType = _testModule.TypeSystem.UInt32;
+            string expected = "456";
+            string actual = Program.FormatEnumMemberValue(value, underlyingType);
+            Assert.AreEqual(expected, actual);
+        }
+        
+        [TestMethod]
+        public void FormatEnumMemberValue_Short_ReturnsStringAsIs()
+        {
+            object value = (short)123;
+            TypeReference underlyingType = _testModule.TypeSystem.Int16;
+            string expected = "123";
+            string actual = Program.FormatEnumMemberValue(value, underlyingType);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void FormatEnumMemberValue_UShort_ReturnsStringAsIs()
+        {
+            object value = (ushort)123;
+            TypeReference underlyingType = _testModule.TypeSystem.UInt16;
+            string expected = "123";
+            string actual = Program.FormatEnumMemberValue(value, underlyingType);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void FormatEnumMemberValue_Byte_ReturnsStringAsIs()
+        {
+            object value = (byte)12;
+            TypeReference underlyingType = _testModule.TypeSystem.Byte;
+            string expected = "12";
+            string actual = Program.FormatEnumMemberValue(value, underlyingType);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void FormatEnumMemberValue_SByte_ReturnsStringAsIs()
+        {
+            object value = (sbyte)-12;
+            TypeReference underlyingType = _testModule.TypeSystem.SByte;
+            string expected = "-12";
+            string actual = Program.FormatEnumMemberValue(value, underlyingType);
+            Assert.AreEqual(expected, actual);
+        }
+    }
+}

--- a/ReflectionGenerator.Tests/GenericConstraintTests.cs
+++ b/ReflectionGenerator.Tests/GenericConstraintTests.cs
@@ -1,0 +1,149 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ReflectionGenerator;
+using Mono.Cecil;
+using System;
+using System.IO;
+using System.Linq;
+
+namespace ReflectionGenerator.Tests
+{
+    [TestClass]
+    public class GenericConstraintTests
+    {
+        private static ModuleDefinition _testModule;
+        private static string _tempOutputDir;
+
+        [ClassInitialize]
+        public static void ClassInitialize(TestContext context)
+        {
+            var assemblyDef = AssemblyDefinition.CreateAssembly(
+                new AssemblyNameDefinition("TestAssemblyForConstraints", new Version(1, 0)),
+                "TestModuleForConstraints",
+                ModuleKind.Dll);
+            _testModule = assemblyDef.MainModule;
+            _tempOutputDir = Path.Combine(Path.GetTempPath(), "ReflectionGenTests_Constraints");
+            if (Directory.Exists(_tempOutputDir))
+            {
+                Directory.Delete(_tempOutputDir, true);
+            }
+            Directory.CreateDirectory(_tempOutputDir);
+        }
+
+        [ClassCleanup]
+        public static void ClassCleanup()
+        {
+            if (Directory.Exists(_tempOutputDir))
+            {
+                Directory.Delete(_tempOutputDir, true);
+            }
+        }
+
+        private string GenerateAndReadFile(TypeDefinition typeDef)
+        {
+            Program.GenerateTypeScaffolding(typeDef, _tempOutputDir);
+            string expectedFileName = Path.Combine(_tempOutputDir, $"{Program.SanitizeFileNameComponent(typeDef.Namespace)}.{Program.SanitizeFileNameComponent(typeDef.Name.Split('`')[0])}.cs");
+            return File.ReadAllText(expectedFileName);
+        }
+        
+        private TypeReference ImportType(Type type)
+        {
+            return _testModule.ImportReference(type);
+        }
+
+        [TestMethod]
+        public void GenerateTypeScaffolding_GenericTypeWithClassConstraint_GeneratesCorrectWhereClause()
+        {
+            var typeDef = new TypeDefinition("MyNs", "MyGenericClass`1", TypeAttributes.Public | TypeAttributes.Class, _testModule.TypeSystem.Object);
+            var pT = new GenericParameter("T", typeDef);
+            pT.HasReferenceTypeConstraint = true; // class constraint
+            typeDef.GenericParameters.Add(pT);
+            _testModule.Types.Add(typeDef);
+
+            string output = GenerateAndReadFile(typeDef);
+            Assert.IsTrue(output.Contains("public partial class MyGenericClass<T> where T : class"));
+            _testModule.Types.Remove(typeDef); // Clean up
+        }
+
+        [TestMethod]
+        public void GenerateTypeScaffolding_GenericTypeWithStructConstraint_GeneratesCorrectWhereClause()
+        {
+            var typeDef = new TypeDefinition("MyNs", "MyValueClass`1", TypeAttributes.Public | TypeAttributes.Class, _testModule.TypeSystem.Object);
+            var pT = new GenericParameter("T", typeDef);
+            pT.HasNotNullableValueTypeConstraint = true; // struct constraint
+            typeDef.GenericParameters.Add(pT);
+             _testModule.Types.Add(typeDef);
+
+            string output = GenerateAndReadFile(typeDef);
+            // Note: struct constraint implies new(), but current generator logic adds new() explicitly if HasDefaultConstructorConstraint is true
+            // Let's assume for now that HasDefaultConstructorConstraint is not set, or adjust if it is.
+            // The `FormatEnumMemberValue` has `!param.HasNotNullableValueTypeConstraint` for `new()`
+            // The `GenerateTypeScaffolding` for type constraints is: if (param.HasDefaultConstructorConstraint && !param.HasNotNullableValueTypeConstraint) paramConstraints.Add("new()");
+            // So, for a pure struct constraint, it should be `where T : struct`
+            Assert.IsTrue(output.Contains("public partial class MyValueClass<T> where T : struct"));
+             _testModule.Types.Remove(typeDef);
+        }
+
+        [TestMethod]
+        public void GenerateTypeScaffolding_GenericTypeWithNewConstraint_GeneratesCorrectWhereClause()
+        {
+            var typeDef = new TypeDefinition("MyNs", "MyCtorClass`1", TypeAttributes.Public | TypeAttributes.Class, _testModule.TypeSystem.Object);
+            var pT = new GenericParameter("T", typeDef);
+            pT.HasDefaultConstructorConstraint = true; // new() constraint
+            typeDef.GenericParameters.Add(pT);
+            _testModule.Types.Add(typeDef);
+
+            string output = GenerateAndReadFile(typeDef);
+            Assert.IsTrue(output.Contains("public partial class MyCtorClass<T> where T : new()"));
+            _testModule.Types.Remove(typeDef);
+        }
+        
+        [TestMethod]
+        public void GenerateTypeScaffolding_GenericTypeWithInterfaceConstraint_GeneratesCorrectWhereClause()
+        {
+            var typeDef = new TypeDefinition("MyNs", "MyInterfaceConstrainedClass`1", TypeAttributes.Public | TypeAttributes.Class, _testModule.TypeSystem.Object);
+            var pT = new GenericParameter("T", typeDef);
+            pT.Constraints.Add(new GenericParameterConstraint(ImportType(typeof(IDisposable))));
+            typeDef.GenericParameters.Add(pT);
+            _testModule.Types.Add(typeDef);
+
+            string output = GenerateAndReadFile(typeDef);
+            Assert.IsTrue(output.Contains("public partial class MyInterfaceConstrainedClass<T> where T : System.IDisposable"));
+             _testModule.Types.Remove(typeDef);
+        }
+
+        [TestMethod]
+        public void GenerateTypeScaffolding_GenericTypeWithMultipleConstraints_GeneratesCorrectWhereClause()
+        {
+            var typeDef = new TypeDefinition("MyNs", "MyMultiConstrainedClass`1", TypeAttributes.Public | TypeAttributes.Class, _testModule.TypeSystem.Object);
+            var pT = new GenericParameter("T", typeDef);
+            pT.HasReferenceTypeConstraint = true;
+            pT.Constraints.Add(new GenericParameterConstraint(ImportType(typeof(IComparable))));
+            pT.HasDefaultConstructorConstraint = true;
+            typeDef.GenericParameters.Add(pT);
+            _testModule.Types.Add(typeDef);
+            
+            string output = GenerateAndReadFile(typeDef);
+            // Order might vary slightly based on implementation, but all constraints should be there.
+            // Current implementation: class, specific types, new()
+            Assert.IsTrue(output.Contains("public partial class MyMultiConstrainedClass<T> where T : class, System.IComparable, new()"));
+            _testModule.Types.Remove(typeDef);
+        }
+
+        [TestMethod]
+        public void GenerateTypeScaffolding_GenericMethodWithConstraint_GeneratesCorrectWhereClause()
+        {
+            var typeDef = new TypeDefinition("MyNs", "ClassWithGenericMethod", TypeAttributes.Public | TypeAttributes.Class, _testModule.TypeSystem.Object);
+            var methodDef = new MethodDefinition("GenericMethod", MethodAttributes.Public, _testModule.TypeSystem.Void);
+            
+            var pM = new GenericParameter("M", methodDef);
+            pM.Constraints.Add(new GenericParameterConstraint(ImportType(typeof(ICloneable))));
+            methodDef.GenericParameters.Add(pM);
+            typeDef.Methods.Add(methodDef);
+            _testModule.Types.Add(typeDef);
+
+            string output = GenerateAndReadFile(typeDef);
+            Assert.IsTrue(output.Contains("public void GenericMethod<M>() where M : System.ICloneable;"));
+            _testModule.Types.Remove(typeDef);
+        }
+    }
+}

--- a/ReflectionGenerator.Tests/ObsoleteAttributeTests.cs
+++ b/ReflectionGenerator.Tests/ObsoleteAttributeTests.cs
@@ -1,0 +1,147 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ReflectionGenerator;
+using Mono.Cecil;
+using System;
+using System.IO;
+using System.Linq;
+
+namespace ReflectionGenerator.Tests
+{
+    [TestClass]
+    public class ObsoleteAttributeTests
+    {
+        private static ModuleDefinition _testModule;
+        private static string _tempOutputDir;
+
+        [ClassInitialize]
+        public static void ClassInitialize(TestContext context)
+        {
+            var assemblyDef = AssemblyDefinition.CreateAssembly(
+                new AssemblyNameDefinition("TestAssemblyForObsolete", new Version(1, 0)),
+                "TestModuleForObsolete",
+                ModuleKind.Dll);
+            _testModule = assemblyDef.MainModule;
+            _tempOutputDir = Path.Combine(Path.GetTempPath(), "ReflectionGenTests_Obsolete");
+            if (Directory.Exists(_tempOutputDir))
+            {
+                Directory.Delete(_tempOutputDir, true);
+            }
+            Directory.CreateDirectory(_tempOutputDir);
+        }
+
+        [ClassCleanup]
+        public static void ClassCleanup()
+        {
+            if (Directory.Exists(_tempOutputDir))
+            {
+                Directory.Delete(_tempOutputDir, true);
+            }
+        }
+
+        private CustomAttribute CreateObsoleteAttribute(string message)
+        {
+            var obsoleteCtor = _testModule.ImportReference(typeof(ObsoleteAttribute).GetConstructor(new[] { typeof(string) }));
+            var attribute = new CustomAttribute(obsoleteCtor);
+            attribute.ConstructorArguments.Add(new CustomAttributeArgument(_testModule.TypeSystem.String, message));
+            return attribute;
+        }
+
+        private string GenerateAndReadFile(TypeDefinition typeDef)
+        {
+            // Ensure type is added to module if not already
+            if (!_testModule.Types.Contains(typeDef))
+            {
+                _testModule.Types.Add(typeDef);
+            }
+            
+            string sanitizedNamespace = string.IsNullOrEmpty(typeDef.Namespace) ? "" : Program.SanitizeFileNameComponent(typeDef.Namespace);
+            string sanitizedTypeName = Program.SanitizeFileNameComponent(typeDef.Name.Split('`')[0]);
+            string expectedFileName = Path.Combine(_tempOutputDir, 
+                string.IsNullOrEmpty(sanitizedNamespace) ? $"{sanitizedTypeName}.cs" : $"{sanitizedNamespace}.{sanitizedTypeName}.cs");
+
+            Program.GenerateTypeScaffolding(typeDef, _tempOutputDir);
+            
+            if (!File.Exists(expectedFileName))
+            {
+                Assert.Fail($"Expected file '{expectedFileName}' was not generated. Namespace: '{typeDef.Namespace}', Name: '{typeDef.Name}'");
+            }
+            return File.ReadAllText(expectedFileName);
+        }
+
+        [TestMethod]
+        public void ObsoleteType_WithMessage_GeneratesCorrectlyEscapedAttribute()
+        {
+            var typeDef = new TypeDefinition("MyNs", "ObsoleteClass", TypeAttributes.Public | TypeAttributes.Class, _testModule.TypeSystem.Object);
+            string message = "This type is \"obsolete\" and has a \nnewline.";
+            string expectedEscapedMessage = "This type is \\\"obsolete\\\" and has a \\nnewline.";
+            typeDef.CustomAttributes.Add(CreateObsoleteAttribute(message));
+            
+            string output = GenerateAndReadFile(typeDef);
+            
+            Assert.IsTrue(output.Contains($"[Obsolete(\"{expectedEscapedMessage}\")]"), "Generated output does not contain correctly escaped Obsolete attribute for type.");
+            _testModule.Types.Remove(typeDef);
+        }
+
+        [TestMethod]
+        public void ObsoleteProperty_WithMessage_GeneratesCorrectlyEscapedAttribute()
+        {
+            var typeDef = new TypeDefinition("MyNs", "ClassWithObsoleteProperty", TypeAttributes.Public | TypeAttributes.Class, _testModule.TypeSystem.Object);
+            var propertyDef = new PropertyDefinition("MyProp", PropertyAttributes.None, _testModule.TypeSystem.Int32);
+            propertyDef.GetMethod = new MethodDefinition("get_MyProp", MethodAttributes.Public | MethodAttributes.SpecialName | MethodAttributes.HideBySig, _testModule.TypeSystem.Int32);
+            typeDef.Methods.Add(propertyDef.GetMethod); // Getter needed for property to be processed
+
+            string message = "Property \"MyProp\" is outdated.";
+            string expectedEscapedMessage = "Property \\\"MyProp\\\" is outdated.";
+            propertyDef.CustomAttributes.Add(CreateObsoleteAttribute(message));
+            typeDef.Properties.Add(propertyDef);
+            
+            string output = GenerateAndReadFile(typeDef);
+
+            Assert.IsTrue(output.Contains($"[Obsolete(\"{expectedEscapedMessage}\")]"), "Generated output does not contain correctly escaped Obsolete attribute for property.");
+            Assert.IsTrue(output.Contains($"public int MyProp {{ get; set; }}"), "Property definition is missing or incorrect.");
+            _testModule.Types.Remove(typeDef);
+        }
+
+        [TestMethod]
+        public void ObsoleteMethod_WithMessage_GeneratesCorrectlyEscapedAttribute()
+        {
+            var typeDef = new TypeDefinition("MyNs", "ClassWithObsoleteMethod", TypeAttributes.Public | TypeAttributes.Class, _testModule.TypeSystem.Object);
+            var methodDef = new MethodDefinition("OldMethod", MethodAttributes.Public, _testModule.TypeSystem.Void);
+            
+            string message = "Method 'OldMethod' uses back\\slash.";
+            string expectedEscapedMessage = "Method 'OldMethod' uses back\\\\slash.";
+            methodDef.CustomAttributes.Add(CreateObsoleteAttribute(message));
+            typeDef.Methods.Add(methodDef);
+            
+            string output = GenerateAndReadFile(typeDef);
+            
+            Assert.IsTrue(output.Contains($"[Obsolete(\"{expectedEscapedMessage}\")]"), "Generated output does not contain correctly escaped Obsolete attribute for method.");
+            Assert.IsTrue(output.Contains($"public void OldMethod();"), "Method definition is missing or incorrect.");
+            _testModule.Types.Remove(typeDef);
+        }
+
+        [TestMethod]
+        public void ObsoleteEnumMember_WithMessage_GeneratesCorrectlyEscapedAttribute()
+        {
+            var typeDef = new TypeDefinition("MyNs", "EnumWithObsoleteMember", TypeAttributes.Public | TypeAttributes.Sealed, _testModule.ImportReference(typeof(Enum)));
+            typeDef.IsEnum = true;
+            // Set underlying type for enum for completeness, though not strictly needed for this test
+            typeDef.Fields.Add(new FieldDefinition("value__", FieldAttributes.Public | FieldAttributes.SpecialName | FieldAttributes.RTSpecialName, _testModule.TypeSystem.Int32));
+
+
+            var enumField = new FieldDefinition("OldValue", FieldAttributes.Public | FieldAttributes.Static | FieldAttributes.Literal | FieldAttributes.HasDefault, typeDef);
+            enumField.Constant = 1; // Enum members must have a constant value.
+            
+            string message = "Enum value 'OldValue' is deprecated \t with a tab.";
+            string expectedEscapedMessage = "Enum value 'OldValue' is deprecated \\t with a tab.";
+            enumField.CustomAttributes.Add(CreateObsoleteAttribute(message));
+            typeDef.Fields.Add(enumField);
+            
+            string output = GenerateAndReadFile(typeDef);
+            
+            StringAssert.Contains(output, $"[Obsolete(\"{expectedEscapedMessage}\")]");
+            StringAssert.Contains(output, "OldValue = 1");
+            _testModule.Types.Remove(typeDef);
+        }
+    }
+}

--- a/ReflectionGenerator.Tests/SanitizeFileNameComponentTests.cs
+++ b/ReflectionGenerator.Tests/SanitizeFileNameComponentTests.cs
@@ -1,0 +1,86 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ReflectionGenerator; // Assuming Program class is in this namespace
+
+namespace ReflectionGenerator.Tests
+{
+    [TestClass]
+    public class SanitizeFileNameComponentTests
+    {
+        [TestMethod]
+        public void SanitizeFileNameComponent_WithValidName_ReturnsSameName()
+        {
+            string input = "ValidName123";
+            string expected = "ValidName123";
+            string actual = Program.SanitizeFileNameComponent(input);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void SanitizeFileNameComponent_WithSpaces_ReplacesSpacesWithUnderscore()
+        {
+            // Although spaces are often allowed, Path.GetInvalidFileNameChars() might include them
+            // or general best practice might be to replace them.
+            // The current implementation of SanitizeFileNameComponent relies on Path.GetInvalidFileNameChars()
+            // and char.IsControl(). If spaces are not in Path.GetInvalidFileNameChars() on the test OS,
+            // they won't be replaced. For this test, we'll assume a context where they *are* replaced or add them to a custom list if not.
+            // For now, let's test common invalid chars explicitly.
+            string input = "Name With Spaces";
+            // This assertion depends on whether space is an invalid char on the OS running the test
+            // For robust testing, one might mock Path.GetInvalidFileNameChars or use a fixed list in SanitizeFileNameComponent
+            // For now, let's assume it's *not* replaced by default unless it's a control char.
+            // To make it a more direct test of *our* logic beyond system defaults, let's use chars we *know* are invalid.
+            input = "Name<With>Invalid:Chars";
+            string expected = "Name_With_Invalid_Chars";
+            string actual = Program.SanitizeFileNameComponent(input);
+            Assert.AreEqual(expected, actual, "Special characters like <, >, : should be replaced.");
+        }
+
+        [TestMethod]
+        public void SanitizeFileNameComponent_WithInvalidChars_ReplacesWithUnderscore()
+        {
+            string input = "Invalid<Name>:\"/\\|?*";
+            string expected = "Invalid_Name_______"; // Each invalid char becomes an underscore
+            string actual = Program.SanitizeFileNameComponent(input);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void SanitizeFileNameComponent_WithControlChars_ReplacesWithUnderscore()
+        {
+            string input = "NameWith\nNewlineAnd\tTab";
+            // \n and \t are control characters
+            string expected = "NameWith_NewlineAnd_Tab";
+            string actual = Program.SanitizeFileNameComponent(input);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void SanitizeFileNameComponent_EmptyString_ReturnsEmptyString()
+        {
+            string input = "";
+            string expected = "";
+            string actual = Program.SanitizeFileNameComponent(input);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void SanitizeFileNameComponent_NullString_ReturnsNull()
+        {
+            string? input = null;
+            string? expected = null;
+            string? actual = Program.SanitizeFileNameComponent(input);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void SanitizeFileNameComponent_NameWithBackticks_KeepsBackticks()
+        {
+            // Backticks are often used in compiler-generated names for generics, but are valid in filenames.
+            // The Split('`') logic is applied *before* calling sanitize, so this test is for the sanitizer itself.
+            string input = "TypeName`1";
+            string expected = "TypeName`1"; // Assuming backtick is not in Path.GetInvalidFileNameChars()
+            string actual = Program.SanitizeFileNameComponent(input);
+            Assert.AreEqual(expected, actual);
+        }
+    }
+}

--- a/ReflectionGenerator.Tests/TypeNameGenerationTests.cs
+++ b/ReflectionGenerator.Tests/TypeNameGenerationTests.cs
@@ -1,0 +1,175 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ReflectionGenerator; // Assuming Program class is in this namespace
+using Mono.Cecil;
+using System;
+using System.Linq; // Required for Linq operations like Select
+
+namespace ReflectionGenerator.Tests
+{
+    [TestClass]
+    public class TypeNameGenerationTests
+    {
+        private static ModuleDefinition _testModule;
+
+        [ClassInitialize]
+        public static void ClassInitialize(TestContext context)
+        {
+            var assemblyDef = AssemblyDefinition.CreateAssembly(
+                new AssemblyNameDefinition("TestAssemblyForTypes", new Version(1, 0)),
+                "TestModuleForTypes",
+                ModuleKind.Dll);
+            _testModule = assemblyDef.MainModule;
+        }
+
+        [TestMethod]
+        public void GetTypeName_SystemInt32_ReturnsIntKeyword()
+        {
+            TypeReference typeRef = _testModule.TypeSystem.Int32;
+            string expected = "int";
+            string actual = Program.GetTypeName(typeRef);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void GetTypeName_SystemString_ReturnsStringKeyword()
+        {
+            TypeReference typeRef = _testModule.TypeSystem.String;
+            string expected = "string";
+            string actual = Program.GetTypeName(typeRef);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void GetTypeName_SystemVoid_ReturnsVoidKeyword()
+        {
+            TypeReference typeRef = _testModule.TypeSystem.Void;
+            string expected = "void";
+            string actual = Program.GetTypeName(typeRef);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void GetTypeName_NullableInt_ReturnsIntQuestionMark()
+        {
+            // Create Nullable<T>
+            var nullableDef = _testModule.ImportReference(typeof(Nullable<>)).Resolve();
+            var genericInstance = new GenericInstanceType(nullableDef);
+            genericInstance.GenericArguments.Add(_testModule.TypeSystem.Int32);
+            
+            string expected = "int?";
+            string actual = Program.GetTypeName(genericInstance);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void GetTypeName_SimpleGenericType_ReturnsCorrectFormat()
+        {
+            // Define a generic type like MyGeneric<T>
+            var genericTypeDef = new TypeDefinition("MyNamespace", "MyGeneric`1", TypeAttributes.Public, _testModule.TypeSystem.Object);
+            var genericParam = new GenericParameter("T", genericTypeDef);
+            genericTypeDef.GenericParameters.Add(genericParam);
+            _testModule.Types.Add(genericTypeDef); // Add to module if it's resolved from here
+
+            // Create an instance MyGeneric<int>
+            var instance = new GenericInstanceType(genericTypeDef);
+            instance.GenericArguments.Add(_testModule.TypeSystem.Int32);
+
+            string expected = "MyNamespace.MyGeneric<int>";
+            string actual = Program.GetTypeName(instance);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void GetTypeName_NestedGenericType_ReturnsCorrectFormat()
+        {
+            // MyOuterGeneric<MyInnerGeneric<string>>
+            var outerTypeDef = new TypeDefinition("MyNamespace", "MyOuterGeneric`1", TypeAttributes.Public, _testModule.TypeSystem.Object);
+            var outerParam = new GenericParameter("TOuter", outerTypeDef);
+            outerTypeDef.GenericParameters.Add(outerParam);
+            _testModule.Types.Add(outerTypeDef);
+
+            var innerTypeDef = new TypeDefinition("MyNamespace", "MyInnerGeneric`1", TypeAttributes.Public, _testModule.TypeSystem.Object);
+            var innerParam = new GenericParameter("TInner", innerTypeDef);
+            innerTypeDef.GenericParameters.Add(innerParam);
+            _testModule.Types.Add(innerTypeDef);
+            
+            var innerInstance = new GenericInstanceType(innerTypeDef);
+            innerInstance.GenericArguments.Add(_testModule.TypeSystem.String); // MyInnerGeneric<string>
+
+            var outerInstance = new GenericInstanceType(outerTypeDef);
+            outerInstance.GenericArguments.Add(innerInstance); // MyOuterGeneric<MyInnerGeneric<string>>
+
+            string expected = "MyNamespace.MyOuterGeneric<MyNamespace.MyInnerGeneric<string>>";
+            string actual = Program.GetTypeName(outerInstance);
+            Assert.AreEqual(expected, actual);
+        }
+        
+        [TestMethod]
+        public void GetTypeName_GenericTypeDefinition_ReturnsNameWithGenericParameters()
+        {
+            var typeDef = new TypeDefinition("MyNamespace", "MyClass`2", TypeAttributes.Public | TypeAttributes.Class, _testModule.TypeSystem.Object);
+            typeDef.GenericParameters.Add(new GenericParameter("T1", typeDef));
+            typeDef.GenericParameters.Add(new GenericParameter("T2", typeDef));
+
+            string expected = "MyNamespace.MyClass<T1, T2>";
+            string actual = Program.GetTypeName(typeDef);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void GetTypeName_NonGenericType_ReturnsFullName()
+        {
+            var typeDef = new TypeDefinition("MyLib.Utils", "Helper", TypeAttributes.Public | TypeAttributes.Class, _testModule.TypeSystem.Object);
+            string expected = "MyLib.Utils.Helper";
+            string actual = Program.GetTypeName(typeDef);
+            Assert.AreEqual(expected, actual);
+        }
+        
+        [TestMethod]
+        public void GetTypeName_GenericParameter_ReturnsName()
+        {
+            var ownerType = new TypeDefinition("MyNamespace", "MyOwnerClass", TypeAttributes.Public, _testModule.TypeSystem.Object);
+            var genericParam = new GenericParameter("TKey", ownerType);
+            // No need to add to ownerType.GenericParameters for this specific test, as GetTypeName directly uses the parameter.
+
+            string expected = "TKey";
+            string actual = Program.GetTypeName(genericParam);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void GetTypeName_TypeWithMultipleGenericArguments_ReturnsCorrectFormat()
+        {
+            var dictDef = _testModule.ImportReference(typeof(System.Collections.Generic.Dictionary<,>)).Resolve();
+            var genericInstance = new GenericInstanceType(dictDef);
+            genericInstance.GenericArguments.Add(_testModule.TypeSystem.String);
+            genericInstance.GenericArguments.Add(_testModule.TypeSystem.Int32);
+
+            // Note: Mono.Cecil might return System.Collections.Generic.Dictionary while C# keyword is dictionary
+            // The GetTypeName method doesn't currently map this specific generic type to a keyword.
+            // It maps System.String to string, System.Int32 to int etc.
+            string expected = "System.Collections.Generic.Dictionary<string, int>";
+            string actual = Program.GetTypeName(genericInstance);
+            Assert.AreEqual(expected, actual);
+        }
+
+
+        [TestMethod]
+        public void GetTypeName_NestedNonGenericType_ReturnsCorrectFullName()
+        {
+            // Simulating OuterType.InnerType
+            var outerType = new TypeDefinition("MyTestNs", "OuterType", TypeAttributes.Public | TypeAttributes.Class, _testModule.TypeSystem.Object);
+            _testModule.Types.Add(outerType);
+            var innerType = new TypeDefinition("", "InnerType", TypeAttributes.NestedPublic | TypeAttributes.Class, _testModule.TypeSystem.Object);
+            outerType.NestedTypes.Add(innerType);
+
+            // GetTypeName expects FullName with "/" for nested types from Cecil, which it converts to "."
+            // Manually constructing such a TypeReference is tricky; usually, it's obtained from an existing type.
+            // Let's use the `innerType` directly, its FullName should be "MyTestNs.OuterType/InnerType"
+            
+            string expected = "MyTestNs.OuterType.InnerType"; // After GetTypeName replaces "/"
+            string actual = Program.GetTypeName(innerType); 
+            Assert.AreEqual(expected, actual);
+        }
+    }
+}


### PR DESCRIPTION
This commit addresses issues in the ReflectionGenerator that could lead to syntactically incorrect C# code and improves its robustness. It also introduces a comprehensive suite of unit tests.

Key changes:
- Improved Generic Type Name Generation: `GetTypeName` now handles nested generics, multiple arguments, nullable types (T?), and maps common types to C# keywords more accurately. Generic type and method declarations now correctly include parameters and constraints (e.g., `where T : IInterface`).
- Sanitized Obsolete Attribute Messages: Special characters (quotes, newlines, etc.) in `[Obsolete]` messages are now properly escaped to prevent syntax errors.
- Improved File Path Generation: Namespace and type names are sanitized to remove/replace invalid file path characters, preventing errors during file writing. Filenames for generic types are also simplified.
- Enhanced Enum Member Generation: Enums now explicitly declare their underlying type (e.g., `: long`). Enum member values are correctly formatted as C# literals (e.g., `123L` for long, `456UL` for ulong).
- Added Unit Tests: A new test project (`ReflectionGenerator.Tests`) was introduced with comprehensive unit tests covering all the above modifications. This includes testing:
    - `SanitizeFileNameComponent`
    - `EscapeStringForAttribute`
    - `FormatEnumMemberValue`
    - `GetTypeName` (various scenarios)
    - Generation of generic constraints
    - Generation of `[Obsolete]` attributes with special characters
    - Overall enum generation (underlying types, flags, member values)

These changes significantly improve the reliability of the generated code and provide a safety net for future modifications.